### PR TITLE
Fix Dependency Review check: remove conflicting deny-licenses

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -56,16 +56,6 @@
               CC-BY-4.0,
               CC0-1.0,
               Unlicense
-            deny-licenses: >-
-              AGPL-1.0-only,
-              AGPL-1.0-or-later,
-              AGPL-3.0-only,
-              AGPL-3.0-or-later,
-              GPL-2.0-only,
-              GPL-3.0-only,
-              LGPL-2.0-only,
-              LGPL-3.0-only,
-              SSPL-1.0
             # Block dependencies with active GitHub Security Advisories
             # in the npm/PyPI/Maven/etc. ecosystems regardless of severity.
             vulnerability-check: true


### PR DESCRIPTION
## Problem
The required **Dependency Review** check has been failing on **every PR** (e.g. #8) with:

```
You cannot specify both allow-licenses and deny-licenses
```

`actions/dependency-review-action@v4` treats `allow-licenses` and `deny-licenses` as mutually exclusive and errors out before doing any actual scanning. Because the check is part of the `main` ruleset, this blocked all merges.

## Fix
Remove the `deny-licenses` block and keep the `allow-licenses` allowlist.

This **preserves the intended policy**: with an allowlist, anything not explicitly listed is rejected — which already covers every license the old denylist named (GPL-2.0/3.0, AGPL-*, LGPL-2.0/3.0, SSPL-1.0). The allowlist keeps the permissive set (Apache-2.0, BSD-2/3-Clause, ISC, MIT, MPL-2.0, CC-BY-4.0, CC0-1.0, Unlicense). `vulnerability-check` and `license-check` remain enabled.

## Effect
Once merged, the Dependency Review check passes on PRs with no disallowed dependency changes, unblocking #8 and future PRs.