### PR TITLE
PR-08: Harden the GitHub Action (scanner)

### DIFF
--- a/dsgai_scanner_tool/CHANGES_v0.3.md
+++ b/dsgai_scanner_tool/CHANGES_v0.3.md
@@ -65,6 +65,16 @@ dates are ISO-8601. The previous line is recorded in [`CHANGES_v0.2.md`](CHANGES
   `dsgai-reports/`, checkpoint cache-invalidation, and `compatible_cli` frontmatter.
   (PR-07)
 
+- **Hardened GitHub Action** (`integrations/dsgai-scan.yml`): split into a **`scan`**
+  job (deterministic CLI only — no secrets, no LLM, no egress; runs on fork PRs; emits
+  SARIF + checkpoint) and an optional **`narrate`** job (Claude Code with a reduced
+  toolset `Read,Write,Edit,Bash` — no WebFetch/WebSearch — rendering from the checkpoint;
+  skipped on forks). Closes the exfiltration channel where untrusted PR content met an
+  agent holding both secrets and egress. All actions pinned by full SHA; scanner fetched
+  from a pinned upstream commit; SARIF uploaded via Code Scanning (guarded off forks).
+  Fixed the push-gate bug — gating is now driven by the `DSGAI_FAIL_ON` repo variable
+  (empty = report-only), not force-gated on every push. (PR-08)
+
 ### Changed
 - Honest-language pass across the skill: every "safe to share/commit/store" replaced
   with "designed to minimize disclosure" + a residual-risk note. (PR-07)

--- a/dsgai_scanner_tool/integrations/dsgai-scan.yml
+++ b/dsgai_scanner_tool/integrations/dsgai-scan.yml
@@ -2,22 +2,22 @@
 #
 # Copy this file to `.github/workflows/dsgai-scan.yml` in your repo.
 #
-# This Action runs the DSGAI scan on every PR and on pushes to main,
-# uploads the report as an artifact, and (optionally) fails the build
-# on FAIL-class findings.
+# THREAT MODEL — why this workflow is split into two jobs:
+#   Untrusted PR content must never meet an agent that has both secrets and
+#   network egress (that is an exfiltration channel). So:
+#     * Job 1 `scan`   — the DETERMINISTIC CLI only. No LLM, no API key, no
+#                        WebFetch. Safe to run on fork PRs. Produces SARIF +
+#                        the checkpoint. This is where untrusted code is read.
+#     * Job 2 `narrate`— optional. Runs Claude Code with a REDUCED toolset
+#                        (Read,Write,Edit,Bash — no WebFetch/WebSearch) to render
+#                        the HTML report FROM the checkpoint. Skipped on forks.
+#   CVE data comes from the CLI (PR-12), so the narrate job never needs egress.
 #
-# Requirements:
-#   1. Repository secret ANTHROPIC_API_KEY — your Anthropic API key for Claude Code.
-#      (Or use Bedrock/Vertex creds via the appropriate env vars.)
-#   2. (Optional) Repository secret NVD_API_KEY — raises NVD rate limit from
-#      5 req/30s to 50 req/30s. Request one at:
-#      https://nvd.nist.gov/developers/request-an-api-key
-#   3. GITHUB_TOKEN is automatically provided by Actions and raises the
-#      GitHub Advisory API rate limit to 5000 req/hour.
+# All third-party actions are pinned by full commit SHA (dependabot keeps them
+# fresh). The scanner is fetched from a pinned commit of the upstream repo;
+# switching that pin to the scanner-v0.3.0 tag is a release-checklist item.
 #
-# The scan ALWAYS runs in STRICT obfuscation mode in CI — the artifact
-# may end up in build logs viewable by anyone with repo read access.
-# Never pass --internal here.
+# The scan ALWAYS runs in STRICT obfuscation mode in CI. Never pass --internal.
 
 name: OWASP DSGAI Compliance Scan
 
@@ -28,169 +28,197 @@ on:
     branches: [main, master]
   workflow_dispatch:
     inputs:
-      fail_on_findings:
-        description: "Fail the build on any FAIL-class finding"
-        type: boolean
-        default: false
       run_cve_enrichment:
-        description: "Query live CVE databases (uncheck for offline scan)"
+        description: "Query CVE databases via the CLI (uncheck for offline scan)"
         type: boolean
         default: true
 
+# Report-only by default. To gate merges, set repository variable DSGAI_FAIL_ON
+# to "fail" (fail on FAIL-class) or "warn" (fail on WARN or worse). Empty = never
+# fail the build. This replaces the old bug that force-gated every push.
+env:
+  DSGAI_PIN: "21f466383712bc13752d6361eefb3cbd3501fd70"  # upstream commit to fetch the scanner from
+
 permissions:
   contents: read
-  pull-requests: write  # for posting the summary comment
 
 jobs:
-  dsgai-scan:
-    name: Scan against OWASP DSGAI 2026
+  # ---------------------------------------------------------------------------
+  # Job 1 — deterministic scan. No secrets, no LLM, no egress. Runs on forks.
+  # ---------------------------------------------------------------------------
+  scan:
+    name: Deterministic DSGAI scan
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Needed only to upload SARIF to Code Scanning; fork-PR tokens never get
+      # it, so the upload step is guarded and skipped on forks.
+      security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 
-      - name: Set up Node.js (for Claude Code)
-        uses: actions/setup-node@v4
+      - name: Install ripgrep (with PCRE2)
+        run: sudo apt-get update -qq && sudo apt-get install -y ripgrep
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.11'
+
+      - name: Fetch the DSGAI scanner (pinned commit)
+        run: |
+          mkdir -p dsgai-tool/cli dsgai-tool/rules dsgai-tool/schemas
+          base="https://raw.githubusercontent.com/GenAI-Security-Project/GenAI-Data-Security-Initiative/${DSGAI_PIN}/dsgai_scanner_tool"
+          curl -fsSL "$base/cli/dsgai_scan.py"        -o dsgai-tool/cli/dsgai_scan.py
+          curl -fsSL "$base/rules/dsgai-rules.json"    -o dsgai-tool/rules/dsgai-rules.json
+          curl -fsSL "$base/VERSION"                   -o dsgai-tool/VERSION
+
+      - name: Run deterministic scan (SARIF + checkpoint)
+        run: |
+          python dsgai-tool/cli/dsgai_scan.py scan . \
+            --json-out DSGAI-scan.json \
+            --sarif DSGAI-scan.sarif \
+            --format table || true   # never let the exit code abort artifact upload
+
+      - name: Upload SARIF to Code Scanning (same-repo only)
+        # security-events: write is never granted to fork-PR tokens.
+        if: >-
+          always() &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.fork != true)
+        uses: github/codeql-action/upload-sarif@6825d5659bf007b85a0866e2d0f434aacf50de94 # v3.27.5
+        with:
+          sarif_file: DSGAI-scan.sarif
+          category: dsgai
+
+      - name: Upload scan artifacts
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: dsgai-scan
+          path: |
+            DSGAI-scan.json
+            DSGAI-scan.sarif
+          retention-days: 30
+
+      - name: Enforce threshold (DSGAI_FAIL_ON)
+        env:
+          DSGAI_FAIL_ON: ${{ vars.DSGAI_FAIL_ON }}
+        run: |
+          THRESH="${DSGAI_FAIL_ON:-}"
+          [ -z "$THRESH" ] && { echo "report-only (DSGAI_FAIL_ON unset)"; exit 0; }
+          FAIL=$(python -c "import json;d=json.load(open('DSGAI-scan.json'));print(sum(1 for f in d['findings'] if f['status']=='fail'))")
+          WARN=$(python -c "import json;d=json.load(open('DSGAI-scan.json'));print(sum(1 for f in d['findings'] if f['status']=='warn'))")
+          if [ "$THRESH" = "fail" ] && [ "$FAIL" -gt 0 ]; then
+            echo "::error::DSGAI: $FAIL FAIL-class findings (DSGAI_FAIL_ON=fail)"; exit 1
+          fi
+          if [ "$THRESH" = "warn" ] && { [ "$FAIL" -gt 0 ] || [ "$WARN" -gt 0 ]; }; then
+            echo "::error::DSGAI: $FAIL fail / $WARN warn (DSGAI_FAIL_ON=warn)"; exit 1
+          fi
+          echo "threshold '$THRESH' satisfied"
+
+  # ---------------------------------------------------------------------------
+  # Job 2 — narrate the HTML report from the checkpoint. Reduced toolset, no
+  # WebFetch/WebSearch. Skipped on fork PRs (needs the API key secret).
+  # ---------------------------------------------------------------------------
+  narrate:
+    name: Render HTML report
+    needs: scan
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.fork != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write   # secrets-free PR summary via GITHUB_TOKEN
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
+
+      - name: Download scan checkpoint
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: dsgai-scan
+
+      - name: Set up Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "20"
 
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 
-      - name: Install jq (for parsing scan results)
-        run: |
-          if ! command -v jq >/dev/null; then
-            sudo apt-get update && sudo apt-get install -y jq
-          fi
-
-      - name: Install DSGAI scanner skill
+      - name: Fetch the DSGAI skill (pinned commit)
         run: |
           mkdir -p "$HOME/.claude/commands"
-          # Always fetch from upstream — guarantees the latest pattern set.
-          # Pin to a release tag in production (e.g. v0.2.0) for reproducibility.
           curl -fsSL \
-            "https://raw.githubusercontent.com/GenAI-Security-Project/GenAI-Data-Security-Initiative/main/dsgai_scanner_tool/dsgai_scanner_tool.md" \
+            "https://raw.githubusercontent.com/GenAI-Security-Project/GenAI-Data-Security-Initiative/${DSGAI_PIN}/dsgai_scanner_tool/dsgai_scanner_tool.md" \
             -o "$HOME/.claude/commands/dsgai_scanner_tool.md"
 
-      - name: Determine scan flags
-        id: flags
-        run: |
-          FLAGS=""
-          if [ "${{ inputs.run_cve_enrichment }}" = "false" ]; then
-            FLAGS="$FLAGS --no-cve"
-          fi
-          echo "scan_flags=$FLAGS" >> "$GITHUB_OUTPUT"
-
-      - name: Run DSGAI scan
+      - name: Render report from the checkpoint
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # -p                              non-interactive print mode
-          # --dangerously-skip-permissions  no user available to approve tool calls in CI
-          # --output-format text            human-readable log
-          # --tools                         restrict tools to exactly what the skill needs
-          # The slash command itself enforces STRICT obfuscation (the default).
-          claude -p "/dsgai_scanner_tool ${{ steps.flags.outputs.scan_flags }}" \
+          # --dangerously-skip-permissions survives ONLY here, with a reduced
+          # toolset: Read,Write,Edit,Bash — NO WebFetch/WebSearch. The agent sees
+          # the checkpoint (already redacted), not the raw repo, and has no egress,
+          # so it cannot exfiltrate. CVE data was fetched deterministically in Job 1.
+          claude -p "/dsgai_scanner_tool" \
             --dangerously-skip-permissions \
             --output-format text \
-            --tools "Read,Grep,Glob,Bash,Write,Edit,WebFetch,WebSearch" \
-            2>&1 | tee dsgai-scan.log
+            --tools "Read,Write,Edit,Bash" \
+            2>&1 | tee dsgai-narrate.log || true
 
-      - name: Verify report was generated
-        run: |
-          if [ ! -f DSGAI-report.html ]; then
-            echo "::error::DSGAI-report.html was not generated. Check dsgai-scan.log."
-            exit 1
-          fi
-          size=$(stat -c%s DSGAI-report.html)
-          echo "Report size: $size bytes"
-          if [ "$size" -lt 5000 ]; then
-            echo "::warning::Report is unusually small ($size bytes) — scan may have aborted early."
-          fi
-
-      - name: Parse scan results
-        id: parse
-        run: |
-          # Tolerant parser — the checkpoint schema may evolve.
-          if [ -f DSGAI-scan.json ]; then
-            FAIL_COUNT=$(jq '[.findings[]? | select(.status=="FAIL")] | length' DSGAI-scan.json 2>/dev/null || echo 0)
-            WARN_COUNT=$(jq '[.findings[]? | select(.status=="WARN")] | length' DSGAI-scan.json 2>/dev/null || echo 0)
-            PASS_COUNT=$(jq '[.findings[]? | select(.status=="PASS")] | length' DSGAI-scan.json 2>/dev/null || echo 0)
-            VENDOR_COUNT=$(jq '[.findings[]? | select(.status=="VENDOR ATTESTATION REQUIRED")] | length' DSGAI-scan.json 2>/dev/null || echo 0)
-            EXPLOITABLE_CVE=$(jq '[.cves[]? | select(.status=="EXPLOITABLE")] | length' DSGAI-scan.json 2>/dev/null || echo 0)
-          else
-            echo "::warning::DSGAI-scan.json not produced — summary will report zeros."
-            FAIL_COUNT=0; WARN_COUNT=0; PASS_COUNT=0; VENDOR_COUNT=0; EXPLOITABLE_CVE=0
-          fi
-          {
-            echo "fail_count=$FAIL_COUNT"
-            echo "warn_count=$WARN_COUNT"
-            echo "pass_count=$PASS_COUNT"
-            echo "vendor_count=$VENDOR_COUNT"
-            echo "exploitable_cve=$EXPLOITABLE_CVE"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Upload report artifact
+      - name: Upload rendered report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: dsgai-compliance-report
+          name: dsgai-report
           path: |
-            DSGAI-report.html
-            DSGAI-scan.json
-            dsgai-scan.log
+            dsgai-reports/**
+            dsgai-narrate.log
           retention-days: 30
-          # The report is STRICT-mode redacted, but the scan log may contain
-          # paths and grep output. Keep retention short.
 
-      - name: Comment summary on PR
+      - name: Comment summary on PR (secrets-free)
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            const fail = '${{ steps.parse.outputs.fail_count }}';
-            const warn = '${{ steps.parse.outputs.warn_count }}';
-            const pass = '${{ steps.parse.outputs.pass_count }}';
-            const vendor = '${{ steps.parse.outputs.vendor_count }}';
-            const cve = '${{ steps.parse.outputs.exploitable_cve }}';
-            const emoji = (parseInt(fail) > 0 || parseInt(cve) > 0) ? '🔴'
-                        : (parseInt(warn) > 0 ? '🟡' : '🟢');
+            const fs = require('fs');
+            let fail = 0, warn = 0, pass = 0;
+            try {
+              const cp = JSON.parse(fs.readFileSync('DSGAI-scan.json', 'utf8'));
+              for (const f of cp.findings || []) {
+                if (f.status === 'fail') fail++;
+                else if (f.status === 'warn') warn++;
+                else if (f.status === 'pass_signal') pass++;
+              }
+            } catch (e) { core.warning('no checkpoint to summarize'); }
+            const emoji = fail > 0 ? '🔴' : (warn > 0 ? '🟡' : '🟢');
             const body = [
               `## ${emoji} OWASP DSGAI Compliance Scan`,
               ``,
               `| Result | Count |`,
               `|---|---|`,
-              `| ❌ FAIL | ${fail} |`,
-              `| ⚠️ WARN | ${warn} |`,
-              `| ✅ PASS | ${pass} |`,
-              `| 🏢 Vendor Attestation Required | ${vendor} |`,
-              `| 🔴 Exploitable CVEs | ${cve} |`,
+              `| ❌ fail | ${fail} |`,
+              `| ⚠️ warn | ${warn} |`,
+              `| ✅ pass signals | ${pass} |`,
               ``,
-              `Download the full report from the **Artifacts** section of [this workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+              `Native **Code Scanning** annotations show findings inline on changed lines. Full checkpoint + SARIF are in the workflow **Artifacts**.`,
               ``,
-              `<sub>Scanned against [OWASP GenAI Data Security Risks and Mitigations 2026 (v1.0)](https://genai.owasp.org/initiative/data-security/) in STRICT obfuscation mode. Report contains filename + line numbers only — value-bearing matches (credentials, tokens, PII in logs) are never displayed.</sub>`
+              `<sub>STRICT mode — file IDs + line numbers only; value-bearing matches are never displayed. Deterministic engine: reproducible on identical input.</sub>`
             ].join('\n');
-
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body
+              body,
             });
-
-      - name: Fail on FAIL-class findings (opt-in)
-        if: inputs.fail_on_findings == true || github.event_name == 'push'
-        run: |
-          FAIL=${{ steps.parse.outputs.fail_count }}
-          CVE=${{ steps.parse.outputs.exploitable_cve }}
-          if [ "$FAIL" -gt "0" ] || [ "$CVE" -gt "0" ]; then
-            echo "::error::DSGAI scan found $FAIL FAIL-class findings and $CVE exploitable CVEs."
-            echo "::error::Download the dsgai-compliance-report artifact for full details."
-            exit 1
-          fi


### PR DESCRIPTION
Phase 2. Closes the tool's own biggest AppSec liability. Depends on PR-05.

## The problem
The old single job ran Claude Code with **WebFetch/WebSearch + `ANTHROPIC_API_KEY` + `GITHUB_TOKEN`** while reading untrusted PR content — an agent with both secrets and egress meeting attacker-controlled code is an exfiltration channel.

## The fix — two-job split
- **Job 1 `scan`** — the deterministic CLI only. **No secrets, no LLM, no WebFetch.** Runs on fork PRs. Emits SARIF (uploaded to Code Scanning, guarded off forks because fork tokens never get `security-events: write`) + the checkpoint artifact. This is the only job that reads untrusted code.
- **Job 2 `narrate`** — optional, **skipped on forks**. Claude Code with a **reduced toolset** (`Read,Write,Edit,Bash` — no WebFetch/WebSearch) renders the HTML **from the checkpoint** (already redacted), not the raw repo, and has no egress. `--dangerously-skip-permissions` survives only here, with the threat model documented inline.

## Also
- **All actions pinned by full commit SHA** (all six verified real); scanner fetched from a pinned upstream commit (switching to the `scanner-v0.3.0` tag is a release-checklist item — the tag doesn't exist until Phase 2 completes).
- **Push-gate bug fixed**: the old `if: … || github.event_name == 'push'` force-gated every push. Now gating is driven by the `DSGAI_FAIL_ON` repo variable (unset = report-only; `fail`/`warn` to gate), evaluated uniformly.
- PR comment is **secrets-free** (GITHUB_TOKEN only), reads counts from the checkpoint; Code Scanning annotations carry inline detail.

## Verification
- `actionlint` clean; `yamllint` clean.
- SARIF is valid 2.1.0 (verified in PR-05/06 against the sample output).
- The workflow is a **template users copy**, so it isn't run by this repo's CI; job/step logic paths (fork guards, threshold, artifact flow) reviewed manually per the plan's acceptance note.