### PR TITLE
PR-10: gitleaks pack + portable pre-commit fallback (scanner)

### DIFF
--- a/dsgai_scanner_tool/CHANGES_v0.3.md
+++ b/dsgai_scanner_tool/CHANGES_v0.3.md
@@ -81,6 +81,16 @@ dates are ISO-8601. The previous line is recorded in [`CHANGES_v0.2.md`](CHANGES
   v0.4). Adds a Contributing quick-start ("found a wrong result? that's a contribution").
   Skill version badge → v0.3. (PR-09)
 
+- **Pre-commit: gitleaks pack + portable fallback** (PR-10). New
+  `integrations/gitleaks/dsgai.toml` — a gitleaks rule pack covering the DSGAI
+  credential set (quote-optional named assignments + raw token prefixes: Slack `xoxb-`,
+  GitHub `ghp_`/`github_pat_`, Google `AIza`, AWS `AKIA`, Anthropic/OpenAI project keys,
+  JWT) with an allowlist for `tests/fixtures/**`, lockfiles, minified JS, and snapshots.
+  `pre-commit-hook.md` now recommends gitleaks as primary. The bespoke
+  `dsgai-secret-scan.sh` fallback is fixed for portability: `mapfile` → a bash-3.2-safe
+  `while read -d ''` loop, `grep -zE` → a `case` filter, quote-optional pattern (catches
+  the unquoted-`.env` miss), plus a token-prefix branch — shellcheck clean.
+
 ### Changed
 - Honest-language pass across the skill **and README**: every "safe to share/commit/store"
   replaced with "designed to minimize disclosure" + a residual-risk note — the Phase-2

--- a/dsgai_scanner_tool/integrations/dsgai-secret-scan.sh
+++ b/dsgai_scanner_tool/integrations/dsgai-secret-scan.sh
@@ -3,9 +3,12 @@
 # Part of the OWASP GenAI Data Security Initiative.
 # https://genai.owasp.org/initiative/data-security/
 #
-# Copy to scripts/dsgai-secret-scan.sh in your repo and chmod +x.
-# See ./pre-commit-hook.md for installation options (pre-commit framework,
-# plain git hook, or Husky).
+# This is the zero-dependency FALLBACK. The recommended pre-commit path is the
+# gitleaks rule pack (integrations/gitleaks/dsgai.toml) — entropy-aware,
+# battle-tested, cross-platform. See ./pre-commit-hook.md.
+#
+# Portable to bash 3.2 (macOS default) and BSD userland: no `mapfile`/`readarray`,
+# no `grep -z`, no `${var,,}`. Copy to scripts/dsgai-secret-scan.sh and chmod +x.
 set -euo pipefail
 
 if ! command -v rg >/dev/null 2>&1; then
@@ -14,18 +17,31 @@ if ! command -v rg >/dev/null 2>&1; then
   exit 0
 fi
 
-# Use -z / -0 so paths containing spaces or newlines are safe.
-mapfile -d '' STAGED < <(
-  git diff --cached --name-only --diff-filter=ACM -z |
-    grep -zE '\.(py|ts|js|java|kt|go|yaml|yml|json|toml|env|cfg)$' || true
-)
+# Collect staged files with a NUL-delimited read loop (bash-3.2 safe — no
+# mapfile). Filter extensions with a case statement (no `grep -z`, which BSD
+# grep lacks). Paths with spaces or newlines are handled correctly.
+STAGED=()
+while IFS= read -r -d '' f; do
+  case "$f" in
+    *.py|*.ts|*.js|*.java|*.kt|*.go|*.yaml|*.yml|*.json|*.toml|*.cfg|*.env|*.env.*)
+      STAGED+=("$f") ;;
+  esac
+done < <(git diff --cached --name-only --diff-filter=ACM -z)
 
 if [ "${#STAGED[@]}" -eq 0 ]; then
   exit 0
 fi
 
-# PCRE pattern: covers LLM, cloud, vector-store, and telemetry credentials.
-PATTERN='(?i)(OPENAI_API_KEY|ANTHROPIC_API_KEY|COHERE_API_KEY|GOOGLE_API_KEY|HF_TOKEN|HUGGINGFACE_TOKEN|AWS_ACCESS_KEY_ID|AZURE_OPENAI_KEY|GCP_SERVICE_ACCOUNT_KEY|QDRANT_API_KEY|PINECONE_API_KEY|WEAVIATE_API_KEY|MILVUS_TOKEN|LANGSMITH_API_KEY|LANGFUSE_PUBLIC_KEY|LANGFUSE_SECRET_KEY)\s*[:=]\s*["'"'"']\S{16,}'
+# Two detections, combined:
+#  1) Named credential assignment, QUOTE-OPTIONAL (fixes the unquoted-.env miss).
+#     The value is 16+ contiguous key-like chars, so `KEY = os.getenv(...)` and
+#     `KEY = os.environ["..."]` do NOT match (the '.'/'(' break the run).
+#  2) Raw token literals by prefix, regardless of variable name (Slack, GitHub,
+#     Google, AWS, Anthropic/OpenAI project keys) — catches keys assigned to
+#     arbitrary names.
+NAMED='(?i)(OPENAI_API_KEY|ANTHROPIC_API_KEY|COHERE_API_KEY|GOOGLE_API_KEY|HF_TOKEN|HUGGINGFACE_TOKEN|AWS_ACCESS_KEY_ID|AZURE_OPENAI_KEY|GCP_SERVICE_ACCOUNT_KEY|QDRANT_API_KEY|PINECONE_API_KEY|WEAVIATE_API_KEY|MILVUS_TOKEN|LANGSMITH_API_KEY|LANGFUSE_PUBLIC_KEY|LANGFUSE_SECRET_KEY)\s*[:=]\s*["'"'"']?[A-Za-z0-9_\-]{16,}'
+PREFIX='(sk-ant-[A-Za-z0-9_\-]{16,}|sk-proj-[A-Za-z0-9_\-]{16,}|ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{22,}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_\-]{35}|AKIA[0-9A-Z]{16})'
+PATTERN="($NAMED|$PREFIX)"
 
 FOUND=$(rg --pcre2 --files-with-matches --no-messages "$PATTERN" "${STAGED[@]}" 2>/dev/null || true)
 

--- a/dsgai_scanner_tool/integrations/gitleaks/dsgai.toml
+++ b/dsgai_scanner_tool/integrations/gitleaks/dsgai.toml
@@ -1,0 +1,53 @@
+# DSGAI credential rule pack for gitleaks.
+# Covers the DSGAI02 credential set with quote-optional assignments and raw
+# token prefixes. Generated to mirror the P02.x / P02.9 rules in
+# dsgai_scanner_tool/rules/dsgai-rules.yaml.
+#
+# Usage:
+#   gitleaks detect  --config integrations/gitleaks/dsgai.toml --source . --no-git
+#   gitleaks protect --config integrations/gitleaks/dsgai.toml --staged   # pre-commit
+#
+# Note: gitleaks uses Go RE2 (no lookaround/backreferences). Patterns here are
+# RE2-safe. `title` matters for report grouping.
+
+title = "DSGAI credential rules"
+
+[[rules]]
+id = "dsgai-openai-key"
+description = "DSGAI02 — OpenAI API key (project or legacy), quote-optional"
+regex = '''(?i)(openai[._-]?api[._-]?key)\s*[:=]\s*["']?sk-[A-Za-z0-9_\-]{20,}'''
+keywords = ["openai", "sk-"]
+
+[[rules]]
+id = "dsgai-anthropic-key"
+description = "DSGAI02 — Anthropic API key, quote-optional"
+regex = '''(?i)(anthropic[._-]?api[._-]?key)\s*[:=]\s*["']?sk-ant-[A-Za-z0-9_\-]{20,}'''
+keywords = ["anthropic", "sk-ant-"]
+
+[[rules]]
+id = "dsgai-named-credential"
+description = "DSGAI02 — named LLM/cloud/vector-store credential assignment, quote-optional"
+regex = '''(?i)(COHERE_API_KEY|GOOGLE_API_KEY|HF_TOKEN|HUGGINGFACE_TOKEN|AWS_ACCESS_KEY_ID|AZURE_OPENAI_KEY|GCP_SERVICE_ACCOUNT_KEY|QDRANT_API_KEY|PINECONE_API_KEY|WEAVIATE_API_KEY|MILVUS_TOKEN|LANGSMITH_API_KEY|LANGFUSE_PUBLIC_KEY|LANGFUSE_SECRET_KEY)\s*[:=]\s*["']?[A-Za-z0-9_\-]{16,}'''
+keywords = ["api_key", "token", "qdrant", "pinecone", "weaviate", "langfuse", "langsmith"]
+
+[[rules]]
+id = "dsgai-token-prefix"
+description = "DSGAI02 — raw token literal by prefix (Slack/GitHub/Google/AWS/Anthropic/OpenAI)"
+regex = '''\b(sk-ant-[A-Za-z0-9_\-]{20,}|sk-proj-[A-Za-z0-9_\-]{20,}|ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{22,}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_\-]{35}|AKIA[0-9A-Z]{16})\b'''
+keywords = ["sk-ant-", "sk-proj-", "ghp_", "github_pat_", "xoxb-", "xoxp-", "AIza", "AKIA"]
+
+[[rules]]
+id = "dsgai-jwt"
+description = "DSGAI02 — JWT triple-segment token (low confidence; noisy in bundles)"
+regex = '''\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b'''
+keywords = ["eyJ"]
+
+[allowlist]
+description = "Fixtures and lockfiles carry intentional fake values; JWTs are noisy in bundles."
+paths = [
+  '''dsgai_scanner_tool/tests/fixtures/.*''',
+  '''.*\.min\.js$''',
+  '''.*\.lock$''',
+  '''.*\.map$''',
+  '''.*/__snapshots__/.*''',
+]

--- a/dsgai_scanner_tool/integrations/pre-commit-hook.md
+++ b/dsgai_scanner_tool/integrations/pre-commit-hook.md
@@ -4,70 +4,72 @@ A lightweight pre-commit hook that runs a fast subset of the DSGAI scan (DSGAI02
 
 This is **not** a substitute for the full scan — it's a fast gate that runs on every commit (sub-second), against staged changes only. Use the full skill (`/dsgai_scanner_tool`) and/or the [GitHub Action](./dsgai-scan.yml) for complete coverage.
 
+**Two options, in order of preference:**
+
+1. **[gitleaks](https://github.com/gitleaks/gitleaks) with the DSGAI rule pack (recommended)** — entropy-aware, battle-tested, cross-platform, no bash quirks. Use this unless you specifically can't add a binary.
+2. **The zero-dependency ripgrep script** — a portable fallback (bash 3.2 / BSD safe) for environments where installing gitleaks isn't an option.
+
+Both detect quote-optional named credentials **and** raw token prefixes (Slack `xoxb-`, GitHub `ghp_`, Google `AIza`, AWS `AKIA`, Anthropic/OpenAI project keys) regardless of variable name.
+
+---
+
+## Recommended — gitleaks with the DSGAI rule pack
+
+Install gitleaks (`brew install gitleaks`, `choco install gitleaks`, or a [release binary](https://github.com/gitleaks/gitleaks/releases)) and copy [`gitleaks/dsgai.toml`](./gitleaks/dsgai.toml) into your repo.
+
+**pre-commit framework** — add to `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: dsgai-gitleaks
+        name: DSGAI02 — gitleaks credential scan
+        entry: gitleaks protect --staged --config integrations/gitleaks/dsgai.toml --no-banner
+        language: system
+        pass_filenames: false
+```
+
+**Plain git hook** — `.git/hooks/pre-commit` (`chmod +x`):
+
+```bash
+#!/usr/bin/env sh
+exec gitleaks protect --staged --config integrations/gitleaks/dsgai.toml --no-banner
+```
+
+Full-tree audit (not just staged): `gitleaks dir . --config integrations/gitleaks/dsgai.toml`. The pack allowlists `tests/fixtures/**`, lockfiles, minified JS, and snapshots.
+
 ---
 
 ## Why a separate hook?
 
-The full DSGAI scan takes 2–5 minutes — too slow for pre-commit. But the most common mistake (hardcoded `sk-...` or `sk-ant-...` keys in `.env` or `config.py`) can be caught in under a second with a pure ripgrep call. This hook does exactly that and nothing more.
+The full DSGAI scan takes minutes — too slow for pre-commit. But the most common mistake (hardcoded `sk-...` or `sk-ant-...` keys, or a raw `xoxb-`/`ghp_` token, in `.env` or `config.py`) can be caught in under a second. Both options above do exactly that and nothing more.
 
 ---
 
-## Step 1 — Drop the shared script into your repo
+## Fallback — Step 1: drop the ripgrep script into your repo
 
-All three installation options call the same script. Copy this into `scripts/dsgai-secret-scan.sh` (or any path you like) and `chmod +x` it:
+If you can't use gitleaks, use the portable ripgrep script. It ships in this repo as [`dsgai-secret-scan.sh`](./dsgai-secret-scan.sh) — copy it to `scripts/dsgai-secret-scan.sh` and `chmod +x` it. It is bash-3.2 / BSD safe (no `mapfile`, no `grep -z`, no `${var,,}`), catches **quote-optional** named credentials and raw token prefixes, and needs nothing beyond ripgrep. Key detection logic:
 
 ```bash
-#!/usr/bin/env bash
-# DSGAI02 — block hardcoded LLM, cloud, and vector-store credentials in staged files.
-# Part of the OWASP GenAI Data Security Initiative.
-set -euo pipefail
-
-if ! command -v rg >/dev/null 2>&1; then
-  echo "warning: ripgrep (rg) not installed; skipping DSGAI02 pre-commit check"
-  echo "         install: https://github.com/BurntSushi/ripgrep#installation"
-  exit 0
-fi
-
-# Use -z / -0 so paths containing spaces or newlines are safe.
-mapfile -d '' STAGED < <(
-  git diff --cached --name-only --diff-filter=ACM -z |
-    grep -zE '\.(py|ts|js|java|kt|go|yaml|yml|json|toml|env|cfg)$' || true
-)
-
-if [ "${#STAGED[@]}" -eq 0 ]; then
-  exit 0
-fi
-
-# PCRE pattern: covers LLM, cloud, vector-store, and telemetry credentials.
-PATTERN='(?i)(OPENAI_API_KEY|ANTHROPIC_API_KEY|COHERE_API_KEY|GOOGLE_API_KEY|HF_TOKEN|HUGGINGFACE_TOKEN|AWS_ACCESS_KEY_ID|AZURE_OPENAI_KEY|GCP_SERVICE_ACCOUNT_KEY|QDRANT_API_KEY|PINECONE_API_KEY|WEAVIATE_API_KEY|MILVUS_TOKEN|LANGSMITH_API_KEY|LANGFUSE_PUBLIC_KEY|LANGFUSE_SECRET_KEY)\s*[:=]\s*["'"'"']\S{16,}'
-
-FOUND=$(rg --pcre2 --files-with-matches --no-messages "$PATTERN" "${STAGED[@]}" 2>/dev/null || true)
-
-if [ -n "$FOUND" ]; then
-  printf '\n❌ DSGAI02 blocked commit: hardcoded credential detected in:\n'
-  printf '%s\n' "$FOUND" | sed 's/^/   - /'
-  cat <<'MSG'
-
-   Move the credential to a secrets manager (HashiCorp Vault, AWS Secrets
-   Manager, GCP Secret Manager, Azure Key Vault) and reference it via an
-   environment variable. NEVER commit the literal value.
-
-   For the full DSGAI compliance scan, run /dsgai_scanner_tool in Claude Code.
-
-   To bypass this check (NOT recommended), commit with --no-verify and add
-   a comment explaining why.
-MSG
-  exit 1
-fi
-
-exit 0
+# Collect staged files with a NUL-delimited read loop (bash-3.2 safe — no mapfile),
+# filter extensions with a case statement (no `grep -z`, which BSD grep lacks).
+STAGED=()
+while IFS= read -r -d '' f; do
+  case "$f" in
+    *.py|*.ts|*.js|*.java|*.kt|*.go|*.yaml|*.yml|*.json|*.toml|*.cfg|*.env|*.env.*)
+      STAGED+=("$f") ;;
+  esac
+done < <(git diff --cached --name-only --diff-filter=ACM -z)
 ```
 
-The script is self-contained — no external dependencies beyond ripgrep.
+See the committed file for the full quote-optional NAMED pattern and the token-PREFIX
+pattern (Slack/GitHub/Google/AWS/Anthropic/OpenAI). The script is self-contained — no
+external dependencies beyond ripgrep.
 
 ---
 
-## Step 2 — Wire it up
+## Fallback — Step 2: wire up the ripgrep script
 
 Pick one of the three integration options that matches your stack.
 
@@ -133,13 +135,13 @@ Run the full skill (`/dsgai_scanner_tool` in Claude Code) periodically — at mi
 
 ## False positives
 
-The pattern intentionally matches `<KEY>\s*[:=]\s*"<16+ chars>"`. If you have legitimate constants or test fixtures that match (`OPENAI_API_KEY = "fake-test-key-for-vcr-cassette"`), choose one of:
+The named pattern matches `<KEY>\s*[:=]\s*<16+ key-like chars>` (quote optional). Because the value must be 16+ contiguous `[A-Za-z0-9_-]`, ordinary env reads like `KEY = os.getenv("KEY")` or `KEY = os.environ["KEY"]` do **not** match (the `.`/`(` break the run). If a legitimate constant still matches, choose one of:
 
-1. **Rename the test fixture** so it doesn't start with the real key name (e.g. `_TEST_OPENAI_KEY_PLACEHOLDER`)
-2. **Exclude the file** by adjusting the `files:` glob in `.pre-commit-config.yaml`, or by gitignoring it if it contains real local-dev secrets
+1. **Rename the test fixture** so it doesn't start with the real key name (e.g. `_TEST_OPENAI_KEY_PLACEHOLDER`), or for gitleaks add it to the `[allowlist]` in `dsgai.toml`
+2. **Exclude the file** by adjusting the `files:` glob / gitleaks allowlist, or by gitignoring it if it contains real local-dev secrets
 3. **One-time bypass** with `git commit --no-verify` and a comment explaining why
 
-**Never** lower the `\S{16,}` minimum length. Real LLM API keys are always 20+ characters; relaxing the length will produce noisy false positives without catching shorter real keys (which don't exist).
+**Never** lower the `{16,}` minimum length. Real LLM API keys are always 20+ characters; relaxing the length will produce noisy false positives without catching shorter real keys (which don't exist).
 
 ---
 


### PR DESCRIPTION
Completes Phase 2 → v0.3 release-ready. Depends on PR-04.

## What's here
- **`integrations/gitleaks/dsgai.toml`** — a gitleaks rule pack for the DSGAI credential set: quote-optional named assignments (OpenAI/Anthropic/Cohere/Google/HF/AWS/Azure/GCP/vector-store/LangSmith/Langfuse) **and** raw token prefixes (`xoxb-`, `ghp_`, `github_pat_`, `AIza`, `AKIA`, `sk-ant-`/`sk-proj-`, JWT). Allowlists `tests/fixtures/**`, lockfiles, minified JS, snapshots.
- **`pre-commit-hook.md`** now recommends **gitleaks as the primary path** (entropy-aware, cross-platform) with pre-commit-framework and plain-hook snippets; the ripgrep script is documented as the zero-dependency fallback.
- **`dsgai-secret-scan.sh` fixed for portability:**
  - `mapfile -d ''` → a bash-3.2-safe `while IFS= read -r -d ''` loop
  - `grep -zE` (BSD grep lacks `-z`) → a `case` extension filter
  - **quote-optional** value pattern (fixes the unquoted-`.env` false negative)
  - new **token-prefix** branch so `xoxb-`/`ghp_`/etc. are caught by any variable name

## Verification (with gitleaks 8.30.1 + the script pattern)
- Both paths **flag** `.env` (unquoted key) and `js-service/index.js` (`xoxb-` token).
- Neither **flags** `good_config.py` (Vault retrieval).
- A **whole-repo** gitleaks scan allowlists `tests/fixtures/**` → **0 fixture leaks**.
- `shellcheck` clean; no bash-4 builtins (bash-3.2 / BSD safe by review).

## Note
A repo-wide gitleaks scan flags `CONTRIBUTING.md`'s fake `sk-proj-FAKE…` example — that's correct (it's a real `sk-proj-` literal). I did **not** globally allowlist `FAKE` values because the fixture detection the acceptance requires depends on those values being detected.