### PR TITLE
PR-11: Pattern precision wave 1 (scanner)

### DIFF
--- a/dsgai_scanner_tool/CHANGES_v0.3.md
+++ b/dsgai_scanner_tool/CHANGES_v0.3.md
@@ -101,4 +101,13 @@ dates are ISO-8601. The previous line is recorded in [`CHANGES_v0.2.md`](CHANGES
   full regeneration from the fixture app lands in PR-09. (PR-02)
 
 ### Fixed
-- _nothing yet_
+- **Confirmed false negative** (unquoted `.env` key): P02.1–P02.5 and P13.4 are now
+  quote-optional, and a new **P02.9** catches raw token literals (`sk-proj-`, `sk-ant-`,
+  `ghp_`, `github_pat_`, `xox[baprs]-`, `AIza`, `AKIA`, JWT) assigned to *any* variable
+  name. The fixture `.env` and the JS `xoxb-` token are now caught. (PR-11)
+- **Confirmed false positive** (innocent webhook flagged as LLM SQL injection): **P12.1**
+  rewritten to LLM-signal variable names and gated on an LLM call within 30 lines
+  (`requires_nearby.pattern`, confidence `medium`). `webhook.py` no longer fires;
+  `sql_agent.py` still does. Both Appendix A commands verified. The CLI gained
+  `requires_nearby.pattern` support and a `drop` outcome for corroborating-signal rules.
+  Zero `known_bug` markers remain in the answer sheet. (PR-11)

--- a/dsgai_scanner_tool/cli/dsgai_scan.py
+++ b/dsgai_scanner_tool/cli/dsgai_scan.py
@@ -50,6 +50,9 @@ COMPOUND_STATUS = {
     "P11.1": {"violation": "fail", "satisfied": "pass_signal"},
     "P18.4": {"violation": "warn", "satisfied": "pass_signal"},
     "P20.5": {"violation": "fail", "satisfied": "pass_signal"},
+    # Corroborating-signal rules: fire only when the nearby signal is PRESENT
+    # (drop the match otherwise). P12.1 is a FAIL only when an LLM call is nearby.
+    "P12.1": {"violation": "drop", "satisfied": "fail"},
 }
 
 # Step-0 detection signals. Raw-endpoint signals catch repos calling LLM APIs
@@ -238,9 +241,9 @@ def nearby(matches_by_rule, required_ids, path, line, window, module_scope):
     return False
 
 
-def resolve_findings(rules, matches_by_rule, detected):
+def resolve_findings(rules, matches_by_rule, detected, nearby_matches=None):
     """Apply subtract / requires_nearby / gating to produce resolved findings."""
-    by_id = {r["id"]: r for r in rules}
+    nearby_matches = nearby_matches or {}
     findings = []
     for rule in rules:
         rid = rule["id"]
@@ -259,14 +262,21 @@ def resolve_findings(rules, matches_by_rule, detected):
                 continue
             status = rule["signal"]
             if rn:
-                required = rn.get("rules") or ([rn["rule"]] if rn.get("rule") else [])
                 window = rn.get("lines", 0)
                 module_scope = rn.get("scope") == "module" or "lines" not in rn
-                need_all = "rules" in rn and rn.get("scope") != "module"
-                sat = _satisfied(matches_by_rule, required, path, line, window,
-                                 module_scope, need_all)
+                if rn.get("pattern"):
+                    # proximity of a raw corroborating pattern (e.g. an LLM call)
+                    sat = any(mp == path and (module_scope or abs(ml - line) <= window)
+                              for (mp, ml) in nearby_matches.get(rid, set()))
+                else:
+                    required = rn.get("rules") or ([rn["rule"]] if rn.get("rule") else [])
+                    need_all = "rules" in rn and rn.get("scope") != "module"
+                    sat = _satisfied(matches_by_rule, required, path, line, window,
+                                     module_scope, need_all)
                 cs = COMPOUND_STATUS.get(rid, {"violation": "fail", "satisfied": "pass_signal"})
                 status = cs["satisfied"] if sat else cs["violation"]
+                if status == "drop":
+                    continue  # corroborating signal absent — not a finding
             findings.append({
                 "control": rule["control"],
                 "rule_id": rid,
@@ -469,16 +479,23 @@ def cmd_scan(args):
     files = discover_files(scoped_target, excludes)
     detected = detect_stack(rg, files, scan_root)
     matches_by_rule = {}
+    nearby_matches = {}
     try:
         for rule in rules:
             candidates = [f for f in files
                           if glob_match(f[1], rule["file_globs"])
                           and not glob_match(f[1], rule.get("exclude_globs") or [])]
             matches_by_rule[rule["id"]] = run_rule(rg, rule, candidates, scan_root)
+            rn = rule.get("requires_nearby") or {}
+            if rn.get("pattern"):
+                # Locate the corroborating pattern (always structural — a code
+                # shape like an LLM call, never a secret) for proximity checks.
+                probe = {"classification": "structural", "pcre": rn["pattern"]}
+                nearby_matches[rule["id"]] = run_rule(rg, probe, candidates, scan_root)
     except RuntimeError as exc:
         eprint(f"error: {exc}")
         return 2
-    findings = resolve_findings(rules, matches_by_rule, detected)
+    findings = resolve_findings(rules, matches_by_rule, detected, nearby_matches)
     controls = classify_controls(rules, findings, detected)
     checkpoint = build_checkpoint(ruleset, findings, controls, scope,
                                   args.obfuscation, args.target)

--- a/dsgai_scanner_tool/rules/dsgai-rules.json
+++ b/dsgai_scanner_tool/rules/dsgai-rules.json
@@ -134,7 +134,7 @@
       "framework": "dsgai-2026-v1.0",
       "id": "P02.1",
       "name": "hardcoded-llm-api-key",
-      "pcre": "(?i)(OPENAI_API_KEY|openai[._-]?api[._-]?key)\\s*[:=]\\s*[\"']sk-[A-Za-z0-9_\\-]{20,}",
+      "pcre": "(?i)(OPENAI_API_KEY|openai[._-]?api[._-]?key)\\s*[:=]\\s*[\"']?sk-[A-Za-z0-9_\\-]{20,}",
       "signal": "fail"
     },
     {
@@ -160,7 +160,7 @@
       "framework": "dsgai-2026-v1.0",
       "id": "P02.2",
       "name": "hardcoded-llm-api-key",
-      "pcre": "(?i)(ANTHROPIC_API_KEY|anthropic[._-]?api[._-]?key)\\s*[:=]\\s*[\"']sk-ant-[A-Za-z0-9_\\-]{20,}",
+      "pcre": "(?i)(ANTHROPIC_API_KEY|anthropic[._-]?api[._-]?key)\\s*[:=]\\s*[\"']?sk-ant-[A-Za-z0-9_\\-]{20,}",
       "signal": "fail"
     },
     {
@@ -186,7 +186,7 @@
       "framework": "dsgai-2026-v1.0",
       "id": "P02.3",
       "name": "hardcoded-cohere-google-hf-tokens",
-      "pcre": "(?i)(COHERE_API_KEY|GOOGLE_API_KEY|HF_TOKEN|HUGGINGFACE_TOKEN)\\s*[:=]\\s*[\"'][A-Za-z0-9_\\-]{20,}",
+      "pcre": "(?i)(COHERE_API_KEY|GOOGLE_API_KEY|HF_TOKEN|HUGGINGFACE_TOKEN)\\s*[:=]\\s*[\"']?[A-Za-z0-9_\\-]{20,}",
       "signal": "fail"
     },
     {
@@ -212,7 +212,7 @@
       "framework": "dsgai-2026-v1.0",
       "id": "P02.4",
       "name": "hardcoded-aws-creds",
-      "pcre": "(AWS_ACCESS_KEY_ID|aws_access_key_id)\\s*[:=]\\s*[\"'][A-Z0-9]{16,}",
+      "pcre": "(AWS_ACCESS_KEY_ID|aws_access_key_id)\\s*[:=]\\s*[\"']?[A-Z0-9]{16,}",
       "signal": "fail"
     },
     {
@@ -238,7 +238,7 @@
       "framework": "dsgai-2026-v1.0",
       "id": "P02.5",
       "name": "hardcoded-azure-gcp-cred",
-      "pcre": "(AZURE_OPENAI_KEY|GCP_SERVICE_ACCOUNT_KEY)\\s*[:=]\\s*[\"'][A-Za-z0-9_\\-]{16,}",
+      "pcre": "(AZURE_OPENAI_KEY|GCP_SERVICE_ACCOUNT_KEY)\\s*[:=]\\s*[\"']?[A-Za-z0-9_\\-]{16,}",
       "signal": "fail"
     },
     {
@@ -318,6 +318,39 @@
       "name": "tool-call-signing",
       "pcre": "(hmac|sign_request|verify_signature|tool_auth|mtls|mutual_tls)",
       "signal": "pass_signal"
+    },
+    {
+      "classification": "value_bearing",
+      "confidence": "high",
+      "control": "DSGAI02",
+      "description": "Raw token literal (Slack/GitHub/Google/AWS/Anthropic/OpenAI/JWT) assigned to any variable",
+      "exclude_globs": [
+        "*.min.js",
+        "dist/**",
+        "**/__snapshots__/**",
+        "*.lock",
+        "*.map"
+      ],
+      "file_globs": [
+        "*.py",
+        "*.ts",
+        "*.js",
+        "*.java",
+        "*.kt",
+        "*.go",
+        "*.env*",
+        "*.yaml",
+        "*.yml",
+        "*.json",
+        "*.toml",
+        "*.cfg"
+      ],
+      "framework": "dsgai-2026-v1.0",
+      "id": "P02.9",
+      "name": "raw-token-literal",
+      "notes": "JWT branch is noisy in bundles/lockfiles (see exclude_globs); further split tracked as a good-first-issue.",
+      "pcre": "\\b(sk-ant-[A-Za-z0-9_\\-]{20,}|sk-proj-[A-Za-z0-9_\\-]{20,}|ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{22,}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_\\-]{35}|AKIA[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,})\\b",
+      "signal": "fail"
     },
     {
       "classification": "structural",
@@ -1278,7 +1311,11 @@
       "framework": "dsgai-2026-v1.0",
       "id": "P12.1",
       "name": "raw-llm-output-execution",
-      "pcre": "execute\\([^)]*(llm|response|completion|output|generated)",
+      "pcre": "(?:\\.execute|\\.run_query|executemany)\\(\\s*(?:f[\"']|[^),]*\\b(llm_\\w*|completion\\w*|generated_sql|generated_query|\\w*\\.content)\\b)",
+      "requires_nearby": {
+        "lines": 30,
+        "pattern": "(chat\\.completions\\.create|messages\\.create|create_sql_agent|SQLDatabaseChain|generate_content)"
+      },
       "signal": "fail"
     },
     {
@@ -1482,7 +1519,7 @@
       "framework": "dsgai-2026-v1.0",
       "id": "P13.4",
       "name": "hardcoded-vector-token",
-      "pcre": "(QDRANT_API_KEY|PINECONE_API_KEY|WEAVIATE_API_KEY)\\s*=\\s*[\"'][A-Za-z0-9_\\-]{16,}",
+      "pcre": "(QDRANT_API_KEY|PINECONE_API_KEY|WEAVIATE_API_KEY)\\s*=\\s*[\"']?[A-Za-z0-9_\\-]{16,}",
       "signal": "fail"
     },
     {

--- a/dsgai_scanner_tool/rules/dsgai-rules.yaml
+++ b/dsgai_scanner_tool/rules/dsgai-rules.yaml
@@ -65,7 +65,7 @@ rules:
     classification: value_bearing
     signal: fail
     confidence: high
-    pcre: '(?i)(OPENAI_API_KEY|openai[._-]?api[._-]?key)\s*[:=]\s*["'']sk-[A-Za-z0-9_\-]{20,}'
+    pcre: '(?i)(OPENAI_API_KEY|openai[._-]?api[._-]?key)\s*[:=]\s*["'']?sk-[A-Za-z0-9_\-]{20,}'
     file_globs: ['*.py', '*.ts', '*.js', '*.java', '*.kt', '*.go', '*.env*', '*.yaml', '*.yml', '*.json', '*.toml', '*.cfg']
     exclude_globs: []
     framework: 'dsgai-2026-v1.0'
@@ -76,7 +76,7 @@ rules:
     classification: value_bearing
     signal: fail
     confidence: high
-    pcre: '(?i)(ANTHROPIC_API_KEY|anthropic[._-]?api[._-]?key)\s*[:=]\s*["'']sk-ant-[A-Za-z0-9_\-]{20,}'
+    pcre: '(?i)(ANTHROPIC_API_KEY|anthropic[._-]?api[._-]?key)\s*[:=]\s*["'']?sk-ant-[A-Za-z0-9_\-]{20,}'
     file_globs: ['*.py', '*.ts', '*.js', '*.java', '*.kt', '*.go', '*.env*', '*.yaml', '*.yml', '*.json', '*.toml', '*.cfg']
     exclude_globs: []
     framework: 'dsgai-2026-v1.0'
@@ -87,7 +87,7 @@ rules:
     classification: value_bearing
     signal: fail
     confidence: high
-    pcre: '(?i)(COHERE_API_KEY|GOOGLE_API_KEY|HF_TOKEN|HUGGINGFACE_TOKEN)\s*[:=]\s*["''][A-Za-z0-9_\-]{20,}'
+    pcre: '(?i)(COHERE_API_KEY|GOOGLE_API_KEY|HF_TOKEN|HUGGINGFACE_TOKEN)\s*[:=]\s*["'']?[A-Za-z0-9_\-]{20,}'
     file_globs: ['*.py', '*.ts', '*.js', '*.java', '*.kt', '*.go', '*.env*', '*.yaml', '*.yml', '*.json', '*.toml', '*.cfg']
     exclude_globs: []
     framework: 'dsgai-2026-v1.0'
@@ -98,7 +98,7 @@ rules:
     classification: value_bearing
     signal: fail
     confidence: high
-    pcre: '(AWS_ACCESS_KEY_ID|aws_access_key_id)\s*[:=]\s*["''][A-Z0-9]{16,}'
+    pcre: '(AWS_ACCESS_KEY_ID|aws_access_key_id)\s*[:=]\s*["'']?[A-Z0-9]{16,}'
     file_globs: ['*.py', '*.ts', '*.js', '*.java', '*.kt', '*.go', '*.env*', '*.yaml', '*.yml', '*.json', '*.toml', '*.cfg']
     exclude_globs: []
     framework: 'dsgai-2026-v1.0'
@@ -109,7 +109,7 @@ rules:
     classification: value_bearing
     signal: fail
     confidence: high
-    pcre: '(AZURE_OPENAI_KEY|GCP_SERVICE_ACCOUNT_KEY)\s*[:=]\s*["''][A-Za-z0-9_\-]{16,}'
+    pcre: '(AZURE_OPENAI_KEY|GCP_SERVICE_ACCOUNT_KEY)\s*[:=]\s*["'']?[A-Za-z0-9_\-]{16,}'
     file_globs: ['*.py', '*.ts', '*.js', '*.java', '*.kt', '*.go', '*.env*', '*.yaml', '*.yml', '*.json', '*.toml', '*.cfg']
     exclude_globs: []
     framework: 'dsgai-2026-v1.0'
@@ -147,6 +147,18 @@ rules:
     exclude_globs: []
     framework: 'dsgai-2026-v1.0'
     description: 'Tool-call signing (PASS)'
+  - id: P02.9
+    control: DSGAI02
+    name: raw-token-literal
+    classification: value_bearing
+    signal: fail
+    confidence: high
+    pcre: '\b(sk-ant-[A-Za-z0-9_\-]{20,}|sk-proj-[A-Za-z0-9_\-]{20,}|ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{22,}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_\-]{35}|AKIA[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b'
+    file_globs: ['*.py', '*.ts', '*.js', '*.java', '*.kt', '*.go', '*.env*', '*.yaml', '*.yml', '*.json', '*.toml', '*.cfg']
+    exclude_globs: ['*.min.js', 'dist/**', '**/__snapshots__/**', '*.lock', '*.map']
+    framework: 'dsgai-2026-v1.0'
+    description: 'Raw token literal (Slack/GitHub/Google/AWS/Anthropic/OpenAI/JWT) assigned to any variable'
+    notes: 'JWT branch is noisy in bundles/lockfiles (see exclude_globs); further split tracked as a good-first-issue.'
   - id: P03.1
     control: DSGAI03
     name: third-party-llm-endpoints
@@ -666,11 +678,12 @@ rules:
     classification: structural
     signal: fail
     confidence: medium
-    pcre: 'execute\([^)]*(llm|response|completion|output|generated)'
+    pcre: '(?:\.execute|\.run_query|executemany)\(\s*(?:f["'']|[^),]*\b(llm_\w*|completion\w*|generated_sql|generated_query|\w*\.content)\b)'
     file_globs: ['*.py', '*.ts', '*.java', '*.kt', '*.go']
     exclude_globs: []
     framework: 'dsgai-2026-v1.0'
     description: 'Raw LLM-output execution (FAIL)'
+    requires_nearby: {pattern: '(chat\.completions\.create|messages\.create|create_sql_agent|SQLDatabaseChain|generate_content)', lines: 30}
   - id: P12.2
     control: DSGAI12
     name: langchain-sql-agent
@@ -777,7 +790,7 @@ rules:
     classification: value_bearing
     signal: fail
     confidence: high
-    pcre: '(QDRANT_API_KEY|PINECONE_API_KEY|WEAVIATE_API_KEY)\s*=\s*["''][A-Za-z0-9_\-]{16,}'
+    pcre: '(QDRANT_API_KEY|PINECONE_API_KEY|WEAVIATE_API_KEY)\s*=\s*["'']?[A-Za-z0-9_\-]{16,}'
     file_globs: ['*.py', '*.ts', '*.java', '*.kt', '*.go', '*.yaml', '*.env*']
     exclude_globs: []
     framework: 'dsgai-2026-v1.0'

--- a/dsgai_scanner_tool/rules/rules.schema.json
+++ b/dsgai_scanner_tool/rules/rules.schema.json
@@ -54,13 +54,15 @@
           "properties": {
             "rule": { "$ref": "#/$defs/ruleId" },
             "rules": { "type": "array", "items": { "$ref": "#/$defs/ruleId" } },
+            "pattern": { "type": "string", "minLength": 1 },
             "lines": { "type": "integer", "minimum": 0 },
             "scope": { "enum": ["module", "file"] },
             "absent": { "type": "boolean" }
           },
           "anyOf": [
             { "required": ["rule"] },
-            { "required": ["rules"] }
+            { "required": ["rules"] },
+            { "required": ["pattern"] }
           ]
         },
         "gated_on": { "enum": ["multimodal", "synthetic_data", "labeling"] },

--- a/dsgai_scanner_tool/tests/expected-findings.yaml
+++ b/dsgai_scanner_tool/tests/expected-findings.yaml
@@ -1,61 +1,64 @@
 # Known-answer sheet for tests/fixtures/vulnerable-app.
 #
-# `findings` is exactly what the CURRENT (v0.2-baseline) ruleset produces on the
-# fixture, with compound logic (subtract / requires_nearby) resolved to a final
-# status. The PR-05 self-test asserts the scan reproduces this set exactly.
-# Line numbers are load-bearing — regenerate with tests/regen_expected.py after
-# editing any fixture and review the diff.
+# `findings` is exactly what the CURRENT ruleset produces on the fixture, with
+# compound logic (subtract / requires_nearby) resolved to a final status. The
+# PR-05 self-test asserts the scan reproduces this set exactly. Line numbers are
+# load-bearing — regenerate with tests/regen_expected.py after editing a fixture.
 #
-# Entries marked `known_bug: true` are WRONG under the v0.2 baseline and flip in
-# the PR named by `fixed_in` (tracked so the suite proves the fix).
+# As of PR-11 there are NO known_bug entries: the confirmed v0.2 false negative
+# (unquoted .env) and false positive (innocent webhook) are fixed and reflected
+# below. P02.9 (raw token literals) now catches keys assigned to arbitrary names.
 framework: dsgai-2026-v1.0
 
 findings:
-  # --- DSGAI02: credentials ---
+  # DSGAI02 — credentials. P02.1 is now quote-optional (catches the unquoted .env);
+  # P02.9 catches raw token literals (sk-proj-, xoxb-, ...) by any variable name.
+  - {control: DSGAI02, rule_id: P02.1, path: .env, line: 3, status: fail, classification: value_bearing}
+  - {control: DSGAI02, rule_id: P02.9, path: .env, line: 3, status: fail, classification: value_bearing}
   - {control: DSGAI02, rule_id: P02.1, path: config.py, line: 7, status: fail, classification: value_bearing}
-  - {control: DSGAI02, rule_id: P02.7, path: good_config.py, line: 11, status: pass_signal}
-  # --- DSGAI04: supply chain ---
-  - {control: DSGAI04, rule_id: P04.1, path: loader.py, line: 10, status: fail}          # torch.load, no weights_only (P04.2 absent)
-  - {control: DSGAI04, rule_id: P04.4, path: requirements.txt, line: 6, status: warn}     # transformers unpinned
-  - {control: DSGAI04, rule_id: P04.4, path: requirements.txt, line: 7, status: warn}     # torch unpinned
-  # --- DSGAI06: MCP / plugin ---
-  - {control: DSGAI06, rule_id: P06.1, path: mcp_config.json, line: 4, status: fail}       # http transport
-  - {control: DSGAI06, rule_id: P06.5, path: server.py, line: 18, status: fail}            # uvicorn 0.0.0.0, P06.2 absent in module
-  # --- DSGAI13: vector store (P13.3 also matches host 0.0.0.0 in server.py under v0.2 globs) ---
-  - {control: DSGAI13, rule_id: P13.3, path: server.py, line: 18, status: warn}
-  # --- DSGAI11: multi-tenant isolation ---
-  - {control: DSGAI11, rule_id: P11.1, path: retriever.py, line: 12, status: fail}         # no P11.2 within 15 lines
-  - {control: DSGAI11, rule_id: P11.1, path: retriever.py, line: 30, status: pass_signal}  # rescued by P11.2 on same line
+  - {control: DSGAI02, rule_id: P02.9, path: config.py, line: 7, status: fail, classification: value_bearing}
+  - {control: DSGAI02, rule_id: P02.7, path: good_config.py, line: 11, status: pass_signal, classification: value_bearing}
+  - {control: DSGAI02, rule_id: P02.9, path: js-service/index.js, line: 11, status: fail, classification: value_bearing}
+  # DSGAI04 — supply chain
+  - {control: DSGAI04, rule_id: P04.1, path: loader.py, line: 10, status: fail}
+  - {control: DSGAI04, rule_id: P04.4, path: requirements.txt, line: 6, status: warn}
+  - {control: DSGAI04, rule_id: P04.4, path: requirements.txt, line: 7, status: warn}
+  # DSGAI06 — MCP / plugin
+  - {control: DSGAI06, rule_id: P06.1, path: mcp_config.json, line: 4, status: fail}
+  - {control: DSGAI06, rule_id: P06.5, path: server.py, line: 18, status: fail}
+  # DSGAI13 — P13.3 also matches host 0.0.0.0 in server.py under v0.2 globs
+  - {control: DSGAI13, rule_id: P13.3, path: server.py, line: 18, status: warn, classification: value_bearing}
+  # DSGAI11 — multi-tenant isolation
+  - {control: DSGAI11, rule_id: P11.1, path: retriever.py, line: 12, status: fail}
+  - {control: DSGAI11, rule_id: P11.1, path: retriever.py, line: 30, status: pass_signal}
   - {control: DSGAI11, rule_id: P11.2, path: retriever.py, line: 30, status: pass_signal}
-  # --- DSGAI05: RAG access control PASS signals (tenant filter) ---
+  # DSGAI05 — RAG tenant-filter PASS signals
   - {control: DSGAI05, rule_id: P05.2, path: retriever.py, line: 30, status: pass_signal}
   - {control: DSGAI05, rule_id: P05.3, path: retriever.py, line: 30, status: pass_signal}
-  # --- DSGAI12: database agent ---
-  - {control: DSGAI12, rule_id: P12.2, path: sql_agent.py, line: 7, status: fail}          # SQLDatabaseChain import
-  - {control: DSGAI12, rule_id: P12.2, path: sql_agent.py, line: 8, status: fail}          # create_sql_agent import
-  - {control: DSGAI12, rule_id: P12.2, path: sql_agent.py, line: 13, status: fail}         # create_sql_agent call
-  - {control: DSGAI12, rule_id: P12.1, path: sql_agent.py, line: 20, status: fail}         # execute(generated_sql)
-  # --- DSGAI15: context window (secret in system prompt) ---
+  # DSGAI12 — database agent. P12.1 now fires only with an LLM call nearby (webhook dropped).
+  - {control: DSGAI12, rule_id: P12.2, path: sql_agent.py, line: 7, status: fail}
+  - {control: DSGAI12, rule_id: P12.2, path: sql_agent.py, line: 8, status: fail}
+  - {control: DSGAI12, rule_id: P12.2, path: sql_agent.py, line: 13, status: fail}
+  - {control: DSGAI12, rule_id: P12.1, path: sql_agent.py, line: 20, status: fail}
+  # DSGAI15 / DSGAI02 — secret in system prompt (P15.1 + P02.9 on the same line)
+  - {control: DSGAI02, rule_id: P02.9, path: system_prompt.py, line: 8, status: fail, classification: value_bearing}
   - {control: DSGAI15, rule_id: P15.1, path: system_prompt.py, line: 8, status: fail, classification: value_bearing}
-  # --- DSGAI14: telemetry content capture ---
+  # DSGAI14 — telemetry content capture
   - {control: DSGAI14, rule_id: P14.2, path: telemetry.py, line: 11, status: warn, classification: value_bearing}
-  # --- DSGAI17 / DSGAI20: PASS signals on the rate-limited endpoint ---
+  # DSGAI17 / DSGAI20 — PASS signals on the rate-limited endpoint
   - {control: DSGAI17, rule_id: P17.4, path: rate_limited_api.py, line: 8, status: pass_signal}
   - {control: DSGAI20, rule_id: P20.2, path: rate_limited_api.py, line: 8, status: pass_signal}
-  - {control: DSGAI20, rule_id: P20.5, path: rate_limited_api.py, line: 19, status: pass_signal}  # endpoint, rescued by nearby P20.1+P20.2
+  - {control: DSGAI20, rule_id: P20.5, path: rate_limited_api.py, line: 19, status: pass_signal}
   - {control: DSGAI20, rule_id: P20.2, path: rate_limited_api.py, line: 20, status: pass_signal}
   - {control: DSGAI20, rule_id: P20.1, path: rate_limited_api.py, line: 21, status: pass_signal}
-  # --- Known v0.2 false positive (flips to must_not_flag in PR-11) ---
-  - {control: DSGAI12, rule_id: P12.1, path: webhook.py, line: 11, status: fail, known_bug: true, fixed_in: PR-11, note: "innocent webhook — P12.1 rewrite removes this"}
 
 # Rules that must NEVER fire on these paths (negative cases).
 must_not_flag:
   - {rule_id: P02.1, path: good_config.py, reason: "secret comes from Vault, not hardcoded"}
+  - {rule_id: P02.9, path: good_config.py, reason: "no raw token literal — Vault retrieval"}
   - {rule_id: P20.5, path: rate_limited_api.py, reason: "endpoint is authenticated and rate limited"}
-  - {rule_id: P12.1, path: webhook.py, reason: "innocent webhook", pending_until: PR-11}
+  - {rule_id: P12.1, path: webhook.py, reason: "innocent webhook — no LLM call nearby (fixed in PR-11)"}
 
-# Things the v0.2 baseline SHOULD flag but misses. PR-11/PR-15 move these into `findings`.
+# Things the ruleset still misses, tracked to the PR that fixes each.
 known_false_negatives:
-  - {control: DSGAI02, rule_id: P02.1, path: .env, line: 3, reason: "unquoted key; v0.2 quote-required pattern misses it", fixed_in: PR-11}
-  - {control: DSGAI02, rule_id: P02.9, path: js-service/index.js, line: 11, reason: "raw xoxb- token on an arbitrary variable; no v0.2 rule matches", fixed_in: PR-11}
   - {control: DSGAI20, rule_id: P20.5, path: js-service/index.js, line: 12, reason: "unauthenticated /chat endpoint; DSGAI20 globs exclude *.js", fixed_in: PR-15}


### PR DESCRIPTION
Phase 3. Kills the two confirmed bugs from Appendix A. Depends on PR-04/PR-05.

## Fixes
- **False negative (unquoted `.env`)** — P02.1–P02.5 and P13.4 are now **quote-optional**, and a new **P02.9** catches raw token literals (`sk-proj-`, `sk-ant-`, `ghp_`, `github_pat_`, `xox[baprs]-`, `AIza`, `AKIA`, JWT) assigned to *any* variable name (JWT-noisy paths in `exclude_globs`). The fixture `.env` key and the JS `xoxb-` token are now caught.
- **False positive (innocent webhook)** — **P12.1** rewritten to LLM-signal variable names and gated on an LLM call within 30 lines (`requires_nearby.pattern`, confidence `medium`). `webhook.py` no longer fires; `sql_agent.py` still does.

## Engine
- The CLI's `requires_nearby` now supports a raw **`pattern`** (a corroborating code shape — always structural, never a secret) and a **`drop`** outcome for fire-only-when-present rules. Schema extended accordingly.

## Verification
- **Both Appendix A commands verified**: case 1 now matches `.env`; case 2 does **not** match `webhook.py` and **does** match `sql_agent.py`.
- `pytest` → **14 passed**, **zero `known_bug`** markers remain.
- Rules schema-valid; `regen --check` confirms all **29** line-pins; JSON in sync with YAML.
- The two `known_false_negatives` PR-11 fixes moved into `findings`; `webhook.py` P12.1 is now a permanent `must_not_flag`.

Closes several of the `blocked-on-phase-1` good-first-issues (P02.1/P02.2/P02.9/P12.1); I'll close those with a back-reference after merge.