### PR TITLE
fix(crosswalk): close js/xss on the framework-control deep link (CodeQL #3, #4)

### DIFF
--- a/crosswalk/docs/index.html
+++ b/crosswalk/docs/index.html
@@ -1497,6 +1497,14 @@ input, select { font-family: inherit; }
     return div.innerHTML;
   }
 
+  // Only a real DOM node may be appended. Anything else — most importantly a
+  // string that reached here from the URL — becomes a text node, so it is
+  // rendered as text and can never be parsed as markup.
+  function toNode(value) {
+    if (value && typeof value.nodeType === 'number') return value;
+    return document.createTextNode(String(value));
+  }
+
   function el(tag, attrs, children) {
     var node = document.createElement(tag);
     if (attrs) {
@@ -1509,8 +1517,8 @@ input, select { font-family: inherit; }
     }
     if (children) {
       if (typeof children === 'string') node.textContent = children;
-      else if (Array.isArray(children)) children.forEach(function(c) { if (c) node.appendChild(c); });
-      else node.appendChild(children);
+      else if (Array.isArray(children)) children.forEach(function(c) { if (c) node.appendChild(toNode(c)); });
+      else node.appendChild(toNode(children));
     }
     return node;
   }
@@ -1634,6 +1642,16 @@ input, select { font-family: inherit; }
     '/review': renderReview
   };
 
+  // Control ids are drawn from 25 separate framework registries and are
+  // punctuation-heavy ("GV-1.7", "Art. 24-27", "A.5.1"), so this bounds the
+  // length and rejects markup delimiters rather than allow-listing a shape
+  // that would reject legitimate ids.
+  function isPlausibleControlId(value) {
+    return typeof value === 'string' &&
+      value.length > 0 && value.length <= 200 &&
+      !/[<>]/.test(value);
+  }
+
   function getRoute() {
     var hash = window.location.hash || '#/';
     // Extract the path part (before any query params)
@@ -1669,9 +1687,15 @@ input, select { font-family: inherit; }
     if (fwControlMatch) {
       var fwNameCtrl = decodeURIComponent(fwControlMatch[1]);
       var ctrlId = decodeURIComponent(fwControlMatch[2]);
-      renderControlDetail(app, fwNameCtrl, ctrlId);
-      window.scrollTo(0, 0);
-      return;
+      // Apply the same allow-list the plain framework route uses below. An
+      // unknown framework name has no registry entry and no mappings, so it
+      // could only ever render an empty page echoing the URL back; fall
+      // through to the frameworks index instead.
+      if (FRAMEWORKS.indexOf(fwNameCtrl) !== -1 && isPlausibleControlId(ctrlId)) {
+        renderControlDetail(app, fwNameCtrl, ctrlId);
+        window.scrollTo(0, 0);
+        return;
+      }
     }
     // Framework detail is a full page, not a modal
     if (frameworkMatch) {

--- a/crosswalk/docs/index.html
+++ b/crosswalk/docs/index.html
@@ -1642,14 +1642,28 @@ input, select { font-family: inherit; }
     '/review': renderReview
   };
 
-  // Control ids are drawn from 25 separate framework registries and are
-  // punctuation-heavy ("GV-1.7", "Art. 24-27", "A.5.1"), so this bounds the
-  // length and rejects markup delimiters rather than allow-listing a shape
-  // that would reject legitimate ids.
-  function isPlausibleControlId(value) {
-    return typeof value === 'string' &&
-      value.length > 0 && value.length <= 200 &&
-      !/[<>]/.test(value);
+  // Resolve a control id supplied in the URL to the canonical string held in
+  // our own data, searching the same three places renderControlDetail reads:
+  // the framework registry, the backlink index, then the mappings in DATA.
+  // Returns null when nothing matches. Callers render the returned value
+  // rather than the URL, so nothing user-supplied is ever put on the page —
+  // a control id that matches nothing could only have produced an empty page
+  // echoing the URL back anyway.
+  function resolveControlId(fwName, controlId) {
+    var regFw = FW_REGISTRY_MAP[fwName];
+    if (regFw) {
+      var regControl = (regFw.controls || []).find(function(c) { return c.control_id === controlId; });
+      if (regControl) return regControl.control_id;
+    }
+    var bl = BACKLINK_MAP[fwName + '::' + controlId];
+    if (bl) return bl.control_id;
+    var found = null;
+    DATA.forEach(function(e) {
+      (e.mappings || []).forEach(function(m) {
+        if (found === null && m.framework === fwName && m.control_id === controlId) found = m.control_id;
+      });
+    });
+    return found;
   }
 
   function getRoute() {
@@ -1687,14 +1701,19 @@ input, select { font-family: inherit; }
     if (fwControlMatch) {
       var fwNameCtrl = decodeURIComponent(fwControlMatch[1]);
       var ctrlId = decodeURIComponent(fwControlMatch[2]);
-      // Apply the same allow-list the plain framework route uses below. An
-      // unknown framework name has no registry entry and no mappings, so it
-      // could only ever render an empty page echoing the URL back; fall
-      // through to the frameworks index instead.
-      if (FRAMEWORKS.indexOf(fwNameCtrl) !== -1 && isPlausibleControlId(ctrlId)) {
-        renderControlDetail(app, fwNameCtrl, ctrlId);
-        window.scrollTo(0, 0);
-        return;
+      // Resolve both halves of the deep link against our own data and render
+      // the resolved values, never the URL text. The framework name gets the
+      // same allow-list the plain framework route uses below; an unknown
+      // framework or control falls through to the frameworks index.
+      var fwIdx = FRAMEWORKS.indexOf(fwNameCtrl);
+      if (fwIdx !== -1) {
+        var knownFw = FRAMEWORKS[fwIdx];
+        var knownCtrl = resolveControlId(knownFw, ctrlId);
+        if (knownCtrl !== null) {
+          renderControlDetail(app, knownFw, knownCtrl);
+          window.scrollTo(0, 0);
+          return;
+        }
       }
     }
     // Framework detail is a full page, not a modal


### PR DESCRIPTION
Closes CodeQL alerts [#3](https://github.com/GenAI-Security-Project/GenAI-Data-Security-Initiative/security/code-scanning/3) and [#4](https://github.com/GenAI-Security-Project/GenAI-Data-Security-Initiative/security/code-scanning/4) — `js/xss`, severity **high**, both open on `main`.

## The flow

Both alerts are one taint path, read out of the analysis SARIF:

```
window.location.hash                      index.html:1638
  -> path                                 index.html:1640
  -> fwControlMatch = path.match(...)      index.html:1653
  -> decodeURIComponent(match[1|2])        index.html:1670-1671
  -> renderControlDetail(fwName, ctrlId)   index.html:1672
  -> el(..., fwName | controlId)           index.html:2671, 2682, 2746
  -> node.appendChild(c)                   index.html:1512-1513   <- sink
```

The sibling route immediately below already allow-lists its input:

```js
if (frameworkMatch) {
  var fwName = decodeURIComponent(frameworkMatch[1]);
  if (FRAMEWORKS.indexOf(fwName) !== -1) {   // <- this check
```

The `fwControlMatch` branch had no equivalent. That asymmetry is the defect.

## Changes

**1. `resolveControlId()` — render resolved data, never URL text.** The route now looks the framework name up in `FRAMEWORKS` and the control id up in the same three places `renderControlDetail` itself reads (framework registry → backlink index → `DATA` mappings), and passes the **stored** strings to the renderer. No URL-derived string reaches the DOM. A deep link that resolves to nothing falls through to the frameworks index — which is all an unmatched id could have rendered anyway, since it has no registry entry and matches no mapping.

**2. `el()` only ever appends a real node.** Children now go through `toNode()`, which returns a DOM node as-is and wraps anything else in a text node. The previous branches passed their argument straight to `appendChild`, which threw a `TypeError` on a string rather than handling it, so this also makes `el()` total.

### Why not a character filter

The first attempt bounded the control id and rejected `<`/`>`. CodeQL still flagged it, correctly — the SARIF showed the `FRAMEWORKS` allow-list *had* cut the framework-name path, but neither remaining guard was a barrier it models:

- the check was a **negated** character class (`!/[<>]/.test(v)`); CodeQL models positive anchored matches
- `toNode` returned its argument unchanged on the node branch, so taint flowed back out to `appendChild`

Resolution is the stronger fix regardless: it is an exact allow-list drawn from our own data, so it needs no opinion about which characters are dangerous. That matters here because control ids come from 25 registries and are punctuation-heavy (`GV-1.7`, `Art. 24-27`, `A.5.1`), and some legitimately aren't in `FW_REGISTRY_MAP` at all — `renderControlDetail` has an explicit `DATA` fallback for exactly that case, which `resolveControlId` mirrors.

## Verification

Every real deep link still resolves to itself — checked against the actual bundles:

| Source | Links | Broken |
| --- | ---: | ---: |
| backlink index | 1097 | **0** |
| framework registry | 1514 | **0** |
| `DATA` mappings | 3210 | **0** |

Payloads all resolve to `null` and fall through: `<img src=x onerror=alert(1)>`, `"><svg/onload=alert(1)>`, `<script>alert(1)</script>` as a framework name, and the `__proto__` / `constructor` keys.

`el()` exercised against the edited source with a DOM shim — 7/7:

- string child still becomes `textContent`, never markup
- array-containing-a-string no longer throws, and lands as a text node (`nodeType 3`)
- element children pass through with identity preserved (`children[0] === kid`)
- falsy array entries still skipped

Inline script parses cleanly (`vm.Script`, 0 syntax errors). `el()` is defined in only one file, so there is no second copy.

**CodeQL on this branch: `No new alerts in code changed by this pull request`, and zero open alerts on the PR head.**

## Notes

`index.html` is hand-maintained — `scripts/generate.js` writes only `docs/data.js`, `docs/backlinks.js`, `docs/frameworks-registry.js` and `docs/incidents.js` — so this edit will not be regenerated away.

Unrelated, spotted while checking id shapes and worth a separate issue: a number of `control_id` values in `frameworks-registry.js` hold prose rather than ids (e.g. `"Providers document obligations; deployers verify"`), and several contain U+FFFD replacement characters from a bad encoding round-trip.
